### PR TITLE
Issues #8 and #9 improve docker image names and tags

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.runtimes</groupId>
     <artifactId>openjdk-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>Google App Engine Logging Support</name>

--- a/openjdk8/pom.xml
+++ b/openjdk8/pom.xml
@@ -67,8 +67,6 @@
             <configuration>
               <imageName>openjdk</imageName>
 	      <imageTags>
-	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
-	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}</imageTag>
 	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${maven.build.timestamp}</imageTag>
 	        <imageTag>${docker.tag.prefix}${openjdk8.version}</imageTag>
 	        <imageTag>${docker.tag.prefix}8</imageTag>
@@ -85,8 +83,6 @@
 	    <configuration>
 	      <imageName>openjdk</imageName>
 	      <imageTags>
-	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
-	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}</imageTag>
 	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${maven.build.timestamp}</imageTag>
 	        <imageTag>${docker.tag.prefix}${openjdk8.version}</imageTag>
 	        <imageTag>${docker.tag.prefix}8</imageTag>

--- a/openjdk8/pom.xml
+++ b/openjdk8/pom.xml
@@ -67,11 +67,11 @@
             <configuration>
               <imageName>openjdk</imageName>
 	      <imageTags>
-	        <imageTag>${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
-	        <imageTag>${openjdk8.version}-${project.version}</imageTag>
-	        <imageTag>${openjdk8.version}-${maven.build.timestamp}</imageTag>
-	        <imageTag>${openjdk8.version}</imageTag>
-	        <imageTag>8</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}</imageTag>
+	        <imageTag>${docker.tag.prefix}8</imageTag>
 	      </imageTags>
               <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
             </configuration>
@@ -85,11 +85,11 @@
 	    <configuration>
 	      <imageName>openjdk</imageName>
 	      <imageTags>
-	        <imageTag>${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
-	        <imageTag>${openjdk8.version}-${project.version}</imageTag>
-	        <imageTag>${openjdk8.version}-${maven.build.timestamp}</imageTag>
-	        <imageTag>${openjdk8.version}</imageTag>
-	        <imageTag>8</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${project.version}</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${docker.tag.prefix}${openjdk8.version}</imageTag>
+	        <imageTag>${docker.tag.prefix}8</imageTag>
 	      </imageTags>
 	    </configuration>
 	  </execution>

--- a/openjdk8/pom.xml
+++ b/openjdk8/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.runtimes</groupId>
     <artifactId>openjdk-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>Google App Engine Image for OpenJDK (openjdk8)</name>
@@ -65,9 +65,13 @@
               <goal>build</goal>
             </goals>
             <configuration>
-              <imageName>openjdk8</imageName>
+              <imageName>openjdk</imageName>
 	      <imageTags>
-	        <imageTag>${docker.tag}</imageTag>
+	        <imageTag>${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${openjdk8.version}-${project.version}</imageTag>
+	        <imageTag>${openjdk8.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${openjdk8.version}</imageTag>
+	        <imageTag>8</imageTag>
 	      </imageTags>
               <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
             </configuration>
@@ -79,9 +83,13 @@
 	      <goal>removeImage</goal>
 	    </goals>
 	    <configuration>
-	      <imageName>openjdk8</imageName>
+	      <imageName>openjdk</imageName>
 	      <imageTags>
-	        <imageTag>${docker.tag}</imageTag>
+	        <imageTag>${openjdk8.version}-${project.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${openjdk8.version}-${project.version}</imageTag>
+	        <imageTag>${openjdk8.version}-${maven.build.timestamp}</imageTag>
+	        <imageTag>${openjdk8.version}</imageTag>
+	        <imageTag>8</imageTag>
 	      </imageTags>
 	    </configuration>
 	  </execution>

--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Create env vars to identify image
 ENV GAE_IMAGE_NAME ${project.artifactId}
-ENV GAE_IMAGE_LABEL ${openjdk8.version}-${project.version}-${maven.build.timestamp}
+ENV GAE_IMAGE_LABEL ${docker.tag.prefix}${openjdk8.version}-${project.version}-${maven.build.timestamp}
 ENV GAE_IMAGE_VERSION ${project.version}
 
 # Update debian 

--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Create env vars to identify image
 ENV GAE_IMAGE_NAME ${project.artifactId}
-ENV GAE_IMAGE_LABEL ${docker.tag}
+ENV GAE_IMAGE_LABEL ${openjdk8.version}-${project.version}-${maven.build.timestamp}
 ENV GAE_IMAGE_VERSION ${project.version}
 
 # Update debian 
@@ -25,7 +25,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
  && apt-get -q update \
  && apt-get -y -q --no-install-recommends install \
     ca-certificates \
-    openjdk-8-jre \
+    openjdk-8-jre=${openjdk8.version}'-*' \
     netbase \
     wget \ 
     unzip \

--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -16,9 +16,9 @@ FROM ${docker.appengine.image}
 ENV DEBIAN_FRONTEND noninteractive
 
 # Create env vars to identify image
+ENV OPENJDK_VERSION ${openjdk8.version}
 ENV GAE_IMAGE_NAME ${project.artifactId}
-ENV GAE_IMAGE_LABEL ${docker.tag.prefix}${openjdk8.version}-${project.version}-${maven.build.timestamp}
-ENV GAE_IMAGE_VERSION ${project.version}
+ENV GAE_IMAGE_LABEL ${docker.tag.prefix}${openjdk8.version}-${maven.build.timestamp}
 
 # Update debian 
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd_HH_mm</maven.build.timestamp.format>
     <appengine.api.version>1.9.40</appengine.api.version>
     <openjdk8.version>8u102</openjdk8.version>
+    <docker.tag.prefix></docker.tag.prefix>
     <docker.appengine.image>gcr.io/google_appengine/base</docker.appengine.image>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.google.cloud.runtimes</groupId>
   <artifactId>openjdk-parent</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Google App Engine OpenJDK Runtime Parent</name>
   <scm>
@@ -32,9 +32,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyy-MM-dd_HH_mm</maven.build.timestamp.format>
     <appengine.api.version>1.9.40</appengine.api.version>
-    <docker.tag>8-jre</docker.tag>
+    <openjdk8.version>8u102</openjdk8.version>
     <docker.appengine.image>gcr.io/google_appengine/base</docker.appengine.image>
   </properties>
 
@@ -156,8 +156,9 @@
         <plugin>
           <groupId>com.spotify</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.3.2</version>
+          <version>0.4.13</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This is a speculative PR for #8 and #9 to start continue the discussion of how we want the
image names and tags to be.

This now builds an image with the following tags (currently with SNAPSHOT):
 - openjdk:8
 - openjdk:8u102
 - openjdk:8u102-1-SNAPSHOT
 - openjdk:8u102-1-SNAPSHOT-2016-09-15_01_31
 - openjdk:8u102-2016-09-15_01_31
 - openjdk:latest

This allows a dependent image to use:

 - the latest version of openjdk
 - the latest version of openjdk:8
 - the latest build of a specific version of openjdk:8u102
 - a specific build of a specific version of openjdk:8u102-1-SNAPSHOT by version
 - a specific build of a specific version of openjdk:8u102-2016-09-15_01_31 by timestamp
 - a specific build of a specific version of openjdk:8u102-1-SNAPSHOT-2016-09-15_01_31 by version and timestamp

The version is now just a single digit release number and if future we could expect multiple
versions of java to be built under a single release number:

 - openjdk:8u108-42-2017-02-01_12_00
 - openjdk:8u108-42
 - openjdk:8u108
 - openjdk:8
 - openjdk:9u2-42-2017-02-01_12_01
 - openjdk:9u2-42
 - openjdk:9u2
 - openjdk:9

It may be a bit over the top having both release number and timestamp, but tags are cheap!