### PR TITLE
Issue #11 Create logging directory for cloud debugger

### DIFF
--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -54,7 +54,9 @@ COPY docker-entrypoint.bash /
 COPY setup-env.bash /
 RUN tar Cxfvz /opt/cdbg /opt/cdbg/cdbg_java_agent.tar.gz --no-same-owner \
  && rm /opt/cdbg/cdbg_java_agent.tar.gz \
- && chmod +x /docker-entrypoint.bash /setup-env.bash
+ && chmod +x /docker-entrypoint.bash /setup-env.bash \
+ && mkdir /var/log/app_engine \
+ && chmod go+rwx /var/log/app_engine
 
 ENTRYPOINT ["/docker-entrypoint.bash"]
 CMD ["java","-version"]


### PR DESCRIPTION
This fixes #11 in openjdk-runtime, but the mkdir in jetty-runtime needs to be removed (separate PR coming)