### PR TITLE
Issue #3 Use GAE_MEMORY_MB * 0.8 for JVM heap default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,19 @@ The entry point for the openjdk8 image is [docker-entrypoint.bash](https://githu
 
 If the default command (java) is used, then the entry point sources the [setup-env.bash](https://github.com/GoogleCloudPlatform/openjdk-runtime/blob/master/openjdk8/src/main/docker/setup-env.bash), which looks for supported features to be enabled and/or configured.  The following table indicates the environment variables that may be used to enable/disable/configure features, any default values if they are not set: 
 
-|Env Var           | Description         | Type     | Default                               |
-|------------------|---------------------|----------|---------------------------------------|
-|`DBG_ENABLE`      | Stackdriver Debugger| boolean  | `true`                                |
-|`TMPDIR`          | Temporary Directory | dirname  |                                       |
-|`JAVA_TMP_OPTS`   | JVM tmpdir args     | JVM args | `-Djava.io.tmpdir=${TMPDIR}`          |
-|`HEAP_SIZE`       | Available heap      | size     | Derived from `/proc/meminfo`          |
-|`JAVA_HEAP_OPTS`  | JVM heap args       | JVM args | `-Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}`   |
-|`JAVA_GC_OPTS`    | JVM GC args         | JVM args | `-XX:+UseG1GC` plus configuration     |
-|`JAVA_GC_LOG`     | JVM GC log file     | filename |                                       |
-|`JAVA_GC_LOG_OPTS`| JVM GC args         | JVM args | Derived from `$JAVA_GC_LOG`           |
-|`JAVA_USER_OPTS`  | JVM other args      | JVM args |                                       |
-|`JAVA_OPTS`       | JVM args            | JVM args | See below                             |
+|Env Var           | Description         | Type     | Default                                     |
+|------------------|---------------------|----------|---------------------------------------------|
+|`DBG_ENABLE`      | Stackdriver Debugger| boolean  | `true`                                      |
+|`TMPDIR`          | Temporary Directory | dirname  |                                             |
+|`JAVA_TMP_OPTS`   | JVM tmpdir args     | JVM args | `-Djava.io.tmpdir=${TMPDIR}`                |
+|`GAE_MEMORY_MB`   | Available memory    | size     | Set by GAE or `/proc/meminfo`-400M          |
+|`HEAP_SIZE_MB`    | Available heap      | size     | 80% of `${GAE_MEMORY_MB}`                   |
+|`JAVA_HEAP_OPTS`  | JVM heap args       | JVM args | `-Xms${HEAP_SIZE_MB}M -Xmx${HEAP_SIZE_MB}M` |
+|`JAVA_GC_OPTS`    | JVM GC args         | JVM args | `-XX:+UseG1GC` plus configuration           |
+|`JAVA_GC_LOG`     | JVM GC log file     | filename |                                             |
+|`JAVA_GC_LOG_OPTS`| JVM GC args         | JVM args | Derived from `$JAVA_GC_LOG`                 |
+|`JAVA_USER_OPTS`  | JVM other args      | JVM args |                                             |
+|`JAVA_OPTS`       | JVM args            | JVM args | See below                                   |
 
 If not explicitly set, `JAVA_OPTS` is defaulted to 
 ```

--- a/openjdk8/src/main/docker/setup-env.bash
+++ b/openjdk8/src/main/docker/setup-env.bash
@@ -21,8 +21,9 @@ fi
 
 # Setup default Java Options
 : ${JAVA_TMP_OPTS:=$( if [[ -z ${TMPDIR} ]]; then echo ""; else echo "-Djava.io.tmpdir=$TMPDIR"; fi)}
-: ${HEAP_SIZE:=$(awk -v frac=${HEAP_SIZE_FRAC:=0.8} -v res=${RAM_RESERVED_MB:=400} /MemTotal/'{ print int($2/1024*frac-res) "M" } ' /proc/meminfo)}
-: ${JAVA_HEAP_OPTS:=-Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}}
+: ${GAE_MEMORY_MB:=$(awk '/MemTotal/{ print int($2/1024-400) }' /proc/meminfo)}
+: ${HEAP_SIZE_MB:=$(expr ${GAE_MEMORY_MB} \* 80 / 100)}
+: ${JAVA_HEAP_OPTS:=-Xms${HEAP_SIZE_MB}M -Xmx${HEAP_SIZE_MB}M}
 : ${JAVA_GC_OPTS:=-XX:+PrintCommandLineFlags -XX:+UseG1GC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+ParallelRefProcEnabled}
 : ${JAVA_GC_LOG_OPTS:=$( if [[ -z ${JAVA_GC_LOG} ]]; then echo ""; else echo "-Xloggc:${JAVA_GC_LOG} -XX:+UseGCLogFileRotation -XX:GCLogFileSize=1048576 -XX:NumberOfGCLogFiles=4"; fi)}
 : ${JAVA_OPTS:=-showversion ${JAVA_TMP_OPTS} ${DBG_AGENT} ${JAVA_HEAP_OPTS} ${JAVA_GC_OPTS} ${JAVA_GC_LOG_OPTS} ${JAVA_USER_OPTS}}


### PR DESCRIPTION
Simplified setup-env.sh to firstly calculate GAE_MEMORY_MB if not set,
then calculate HEAP_MEMORY_MB (if not set) to 80% of GAE_MEMORY_MB
Currently needs fix for #11 applied before it will run out of the box.