### PR TITLE
Issue https://github.com/GoogleCloudPlatform/jetty-runtime/issues/120

### DIFF
--- a/openjdk8/src/main/docker/docker-entrypoint.bash
+++ b/openjdk8/src/main/docker/docker-entrypoint.bash
@@ -2,7 +2,10 @@
 
 # source the supported feature JVM arguments
 source /setup-env.bash
-  
+if [ -x /app-env.bash ] ; then
+  source /app-env.bash
+fi
+
 # If the first argument is the java command
 if [ "java" = "$1" -o "$(which java)" = "$1" ] ; then
   # ignore it as java is the default command


### PR DESCRIPTION
Make docker-entrypoint easily extensible for https://github.com/GoogleCloudPlatform/jetty-runtime/issues/120