### PR TITLE
Fix an issue where cloudbuild.sh fails to run

### DIFF
--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -25,6 +25,7 @@ CANDIDATE_NAME="8-`date +%Y-%m-%d_%H_%M`"
 export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
 echo "IMAGE: $IMAGE"
 
+mkdir -p $projectRoot/target
 envsubst < $projectRoot/cloudbuild.yaml.in > $projectRoot/target/cloudbuild.yaml
 
 gcloud container builds submit --config=$projectRoot/target/cloudbuild.yaml .


### PR DESCRIPTION
In particular, on a fresh checkout, running `scripts/cloudbuild.sh` would fail because a `target` directory
doesn't exist in the project root directory.  This is probably because `git` doesn't track empty directories.