### PR TITLE
Tagging improvements when using cloudbuild

### DIFF
--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -4,13 +4,13 @@
 steps:
 # Build the maven project, omitting the docker build step
 - name: 'gcr.io/cloud-builders/maven'
-  args: ['mvn', '-P-local-docker-build', 'clean', 'install', '-Ddocker.tag.long=${DOCKER_TAG_LONG}']
+  args: ['mvn', '-P-local-docker-build', 'clean', 'install' ]
 # Execute the docker build
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=${IMAGE}', '--no-cache', 'openjdk8/target/docker']
+  args: ['build', '--tag=${IMAGE_SHORT}', '--tag=${IMAGE_LONG}', '--no-cache', 'openjdk8/target/docker']
 # Test the built image
 # See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests
 - name: 'gcr.io/gcp-runtimes/structure_test'
-  args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/openjdk8/target/test-classes/structure.yaml']
+  args: ['--image', '${IMAGE_LONG}', '-v', '--config', '/workspace/openjdk8/target/test-classes/structure.yaml']
 
-images: ['${IMAGE}']
+images: ['${IMAGE_SHORT}', '${IMAGE_LONG}']

--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -4,13 +4,13 @@
 steps:
 # Build the maven project, omitting the docker build step
 - name: 'gcr.io/cloud-builders/maven'
-  args: ['mvn', '-P-local-docker-build', 'clean', 'install' ]
+  args: ['mvn', '-P-local-docker-build', 'clean', 'install']
 # Execute the docker build
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=${IMAGE_SHORT}', '--tag=${IMAGE_LONG}', '--no-cache', 'openjdk8/target/docker']
+  args: ['build', '--tag=${IMAGE}', '--no-cache', 'openjdk8/target/docker']
 # Test the built image
 # See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests
 - name: 'gcr.io/gcp-runtimes/structure_test'
-  args: ['--image', '${IMAGE_LONG}', '-v', '--config', '/workspace/openjdk8/target/test-classes/structure.yaml']
+  args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/openjdk8/target/test-classes/structure.yaml']
 
-images: ['${IMAGE_SHORT}', '${IMAGE_LONG}']
+images: ['${IMAGE}']

--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -20,10 +20,13 @@ projectRoot=`dirname $0`/..
 
 DOCKER_NAMESPACE='gcr.io/$PROJECT_ID'
 RUNTIME_NAME="openjdk"
+export DOCKER_TAG_SHORT="8"
 export DOCKER_TAG_LONG="8-`date +%Y-%m-%d-%H-%M`"
 
-export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
-echo "IMAGE: $IMAGE"
+export IMAGE_SHORT="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_SHORT}"
+export IMAGE_LONG="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
+echo "IMAGE_SHORT: $IMAGE_SHORT"
+echo "IMAGE_LONG: $IMAGE_LONG"
 
 mkdir -p $projectRoot/target
 envsubst < $projectRoot/cloudbuild.yaml.in > $projectRoot/target/cloudbuild.yaml

--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -20,13 +20,10 @@ projectRoot=`dirname $0`/..
 
 DOCKER_NAMESPACE='gcr.io/$PROJECT_ID'
 RUNTIME_NAME="openjdk"
-export DOCKER_TAG_SHORT="8"
 export DOCKER_TAG_LONG="8-`date +%Y-%m-%d-%H-%M`"
 
-export IMAGE_SHORT="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_SHORT}"
-export IMAGE_LONG="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
-echo "IMAGE_SHORT: $IMAGE_SHORT"
-echo "IMAGE_LONG: $IMAGE_LONG"
+export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
+echo "IMAGE: $IMAGE"
 
 mkdir -p $projectRoot/target
 envsubst < $projectRoot/cloudbuild.yaml.in > $projectRoot/target/cloudbuild.yaml


### PR DESCRIPTION
This PR makes a few improvements to the way we handle tags when using cloud build.

* removes the `-Ddocker.tag.long=${DOCKER_TAG_LONG}` maven argument when using cloud build. (This argument doesn't do anything since we explicitly disable the maven docker build profile).
* ~~Tags the built image with the short tag, as well as the long tag. This is to have parity between the maven-built docker tags (for local development) and the cloudbuild docker tags.~~