### PR TITLE
Change long_tag to show UTC timestamp

### DIFF
--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -20,7 +20,7 @@ projectRoot=`dirname $0`/..
 
 DOCKER_NAMESPACE='gcr.io/$PROJECT_ID'
 RUNTIME_NAME="openjdk"
-export DOCKER_TAG_LONG="8-`date +%Y-%m-%d-%H-%M`"
+export DOCKER_TAG_LONG="8-`date -u +%Y-%m-%d-%H-%M`"
 
 export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
 echo "IMAGE: $IMAGE"


### PR DESCRIPTION
Maven build timestamps are displayed in the UTC timezone. We should do the same with timestamps generated for cloud builds.