### PR TITLE
Use maven properties for cloud build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,24 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>
+                ${project.build.directory}/build.properties
+              </outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -17,11 +17,19 @@
 set -e
 
 projectRoot=`dirname $0`/..
+buildProperties=$projectRoot/target/build.properties
+
+# reads a property value from a .properties file
+function read_prop {
+  grep "${1}" $buildProperties | cut -d'=' -f2
+}
+
+# invoke local maven to generate build properties file
+mvn generate-resources
 
 DOCKER_NAMESPACE='gcr.io/$PROJECT_ID'
 RUNTIME_NAME="openjdk"
-export DOCKER_TAG_LONG="8-`date -u +%Y-%m-%d-%H-%M`"
-
+DOCKER_TAG_LONG=$(read_prop "docker.tag.long")
 export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
 echo "IMAGE: $IMAGE"
 


### PR DESCRIPTION
Reuses maven properties in the cloud builder pipeline, so we don't need to define our tag formats in more than one place. See also https://github.com/GoogleCloudPlatform/jetty-runtime/pull/135 for more discussion.