### PR TITLE
Add JDK tools to the image

### DIFF
--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
  && apt-get -y -q --no-install-recommends install \
     ca-certificates-java=20161107'*' \
     openjdk-8-jre-headless=${openjdk.version}'-*' \
+    openjdk-8-jdk-headless=${openjdk.version}'-*' \
     netbase \
     wget \ 
     unzip \

--- a/openjdk8/src/test/resources/structure.yaml
+++ b/openjdk8/src/test/resources/structure.yaml
@@ -10,7 +10,7 @@ commandTests:
   expectedError: ['openjdk version "1\.${openjdk.version.major}.*${openjdk.version.minor}"']
 - name: 'correct javac version is installed'
   command: ['javac', '-version']
-  expectedError: ['javac version "1\.${openjdk.version.major}.*${openjdk.version.minor}"']
+  expectedError: ['javac 1\.${openjdk.version.major}.*${openjdk.version.minor}']
 - name: 'OPENJDK_VERSION env variable is set correctly'
   command: ['env']
   expectedOutput: ['OPENJDK_VERSION=${openjdk.version}']

--- a/openjdk8/src/test/resources/structure.yaml
+++ b/openjdk8/src/test/resources/structure.yaml
@@ -8,6 +8,9 @@ commandTests:
 - name: 'correct java version is installed'
   command: ['java', '-version']
   expectedError: ['openjdk version "1\.${openjdk.version.major}.*${openjdk.version.minor}"']
+- name: 'correct javac version is installed'
+  command: ['javac', '-version']
+  expectedError: ['javac version "1\.${openjdk.version.major}.*${openjdk.version.minor}"']
 - name: 'OPENJDK_VERSION env variable is set correctly'
   command: ['env']
   expectedOutput: ['OPENJDK_VERSION=${openjdk.version}']


### PR DESCRIPTION
This adds javac, jcmd, etc. It's about ~40MB extra, but I think is worth the cost for providing building, monitoring, and debugging tools to the image.