### PR TITLE
Make builds work independent of working dir

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,6 +43,6 @@ else
   gcloud container builds submit \
     --config=$projectRoot/cloudbuild.yaml \
     --substitutions="_IMAGE=$IMAGE,_DOCKER_TAG=$DOCKER_TAG" \
-    .
+    $projectRoot
 fi
 


### PR DESCRIPTION
When uploading build context to Cloud Container Builder, use the `$projectRoot` rather than the current directory, so that this script works regardless of your current directory when running this script.