### PR TITLE
Adds openjdk-8-dbg to installed packages so jmap -heap works.

### DIFF
--- a/openjdk8/src/main/docker/Dockerfile
+++ b/openjdk8/src/main/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/a
     netbase \
     wget \ 
     unzip \
+    openjdk-8-dbg \
  && apt-get clean \
  && rm /var/lib/apt/lists/*_*
 


### PR DESCRIPTION
Fixes #80 