### PR TITLE
Pin to integration test image

### DIFF
--- a/scripts/integration_test.yaml
+++ b/scripts/integration_test.yaml
@@ -3,7 +3,7 @@
 steps:
   # Runtimes-common integration tests
   # See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/integration_tests
-  - name: 'gcr.io/gcp-runtimes/integration_test'
+  - name: 'gcr.io/gcp-runtimes/integration_test:2017-03-23-134436'
     args:
       - '--no-deploy'
       - '--url=${_DEPLOYED_APP_URL}'


### PR DESCRIPTION
We should pin to the specific image that we use for integration testing so that our tests don't get broken.