### PR TITLE
Sets RUNTIME_DIR in runtimes, instead of openjdk base image.

### DIFF
--- a/openjdk8/src/main/docker/setup-env.d/20-debug-env.bash
+++ b/openjdk8/src/main/docker/setup-env.d/20-debug-env.bash
@@ -8,4 +8,5 @@ fi
 
 if [ "$DBG_ENABLE" = "true" ]; then
   unset CDBG_DISABLE
+  DBG_AGENT="$(/opt/cdbg/format-env-appengine-vm.sh)"
 fi

--- a/openjdk8/src/main/docker/setup-env.d/20-debug-env.bash
+++ b/openjdk8/src/main/docker/setup-env.d/20-debug-env.bash
@@ -8,5 +8,4 @@ fi
 
 if [ "$DBG_ENABLE" = "true" ]; then
   unset CDBG_DISABLE
-  DBG_AGENT="$( RUNTIME_DIR=$JETTY_BASE /opt/cdbg/format-env-appengine-vm.sh )"
 fi


### PR DESCRIPTION
Helps fixing #64

Used in conjunction with https://github.com/GoogleCloudPlatform/jetty-runtime/pull/164

Will also require a change in format-env-appengine-vm.sh 