### PR TITLE
Add integration test for GKE

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -32,7 +32,7 @@ $ ./scripts/build.sh gcr.io/$PROJECT_ID $TAG --local
 
 # Running Tests
 Integration tests can be run via [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/overview).
-These tests deploy a sample test application to App Engine using the provided runtime image, and 
+These tests deploy a sample test application to App Engine and to Google Container Engine using the provided runtime image, and
 exercise various integrations with other GCP services. Note that the image under test must be pushed 
 to a gcr.io repository before the integration tests can run.
 ```bash
@@ -41,3 +41,14 @@ $ gcloud docker -- push $RUNTIME_IMAGE
 $ ./scripts/integration_test.sh $RUNTIME_IMAGE
 ```
 
+You also have the possibility to run the tests only on App Engine or only on Google Container Engine.
+
+* For App Engine:
+```bash
+$ ./scripts/ae_integration_test.sh $RUNTIME_IMAGE
+```
+
+* For Google Container Engine:
+```bash
+$ ./scripts/gke_integration_test.sh $RUNTIME_IMAGE
+```

--- a/scripts/ae_integration_test.sh
+++ b/scripts/ae_integration_test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Runs integration tests on a given runtime image
+
+dir=`dirname $0`
+projectRoot=$dir/..
+testAppDir=$projectRoot/test-application
+deployDir=$testAppDir/target/deploy
+
+imageUnderTest=$1
+if [ -z "${imageUnderTest}" ]; then
+  echo "Usage: ${0} <image_under_test>"
+  exit 1
+fi
+
+# build the test app
+pushd $testAppDir
+mvn clean install
+popd
+
+# deploy to app engine
+pushd $deployDir
+export STAGING_IMAGE=$imageUnderTest
+envsubst < Dockerfile.in > Dockerfile
+echo "Deploying to App Engine..."
+gcloud app deploy -q
+popd
+
+DEPLOYED_APP_URL="http://$(gcloud app describe | grep defaultHostname | awk '{print $2}')"
+echo "Running integration tests on application that is deployed at $DEPLOYED_APP_URL"
+
+# run in cloud container builder
+gcloud container builds submit \
+  --config $dir/integration_test.yaml \
+  --substitutions "_DEPLOYED_APP_URL=$DEPLOYED_APP_URL" \
+  $dir
+

--- a/scripts/gke_integration_test.sh
+++ b/scripts/gke_integration_test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup environment for CI with GKE.
+# This include:
+# - Building a test application into a docker image
+# - Upload the image to Google Container Registry
+# - Create a Kubernetes cluster on GKE
+# - Deploy the application
+# - Run the integration test
+set -e
+
+readonly dir=$(dirname $0)
+readonly projectRoot="$dir/.."
+readonly testAppDir="$projectRoot/test-application"
+readonly deployDir="$testAppDir/target/deploy"
+
+readonly projectName=$(gcloud info \
+                | awk '/^Project: / { print $2 }' \
+                | sed 's/\[//'  \
+                | sed 's/\]//')
+readonly imageName="openjdk-gke-integration"
+readonly imageUrl="gcr.io/$projectName/$imageName"
+readonly clusterName="openjdk-gke-integration"
+
+readonly imageUnderTest=$1
+if [[ -z "$imageUnderTest" ]]; then
+  echo "Usage: ${0} <image_under_test>"
+  exit 1
+fi
+
+# build the test app
+pushd ${testAppDir}
+mvn clean install
+popd
+
+# deploy to app engine
+pushd ${deployDir}
+export STAGING_IMAGE=${imageUnderTest}
+envsubst < "Dockerfile.in" > "Dockerfile"
+export TESTED_IMAGE=${imageUrl}
+envsubst < "openjdk-spring-boot.yaml.in" > "openjdk-spring-boot.yaml"
+
+echo "Deploying image to Google Container Engine..."
+docker build -t "$imageName" .
+docker tag "$imageName" "$imageUrl"
+gcloud docker -- push gcr.io/${projectName}/openjdk-gke-integration
+
+echo "Creating or searching for a Kubernetes cluster..."
+TEST_CLUSTER_EXISTENCE=$(gcloud container clusters list | awk "/$clusterName/")
+if [ -z "$TEST_CLUSTER_EXISTENCE" ]; then
+  gcloud container clusters create "$clusterName" --num-nodes=1 --disk-size=10
+fi
+
+echo "Deploying application to Google Container Engine..."
+gcloud container clusters get-credentials ${clusterName}
+kubectl apply -f "openjdk-spring-boot.yaml"
+popd
+
+echo "Waiting for the application to be accessible (expected time: ~1min)"
+DEPLOYED_APP_URL=""
+while [[ -z "$DEPLOYED_APP_URL" ]]; do
+  sleep 5
+  DEPLOYED_APP_URL=$(kubectl describe services openjdk-spring-boot \
+                             | awk '/LoadBalancer Ingress/ { print $3 }')
+done
+
+# run in cloud container builder
+echo "Running integration tests on application that is deployed at $DEPLOYED_APP_URL"
+gcloud container builds submit \
+  --config ${dir}/integration_test.yaml \
+  --substitutions "_DEPLOYED_APP_URL=http://$DEPLOYED_APP_URL" \
+  ${dir}

--- a/scripts/gke_integration_test.sh
+++ b/scripts/gke_integration_test.sh
@@ -47,17 +47,17 @@ pushd ${testAppDir}
 mvn clean install
 popd
 
-# deploy to app engine
+# deploy to Google Container Engine
 pushd ${deployDir}
 export STAGING_IMAGE=${imageUnderTest}
 envsubst < "Dockerfile.in" > "Dockerfile"
 export TESTED_IMAGE=${imageUrl}
 envsubst < "openjdk-spring-boot.yaml.in" > "openjdk-spring-boot.yaml"
 
-echo "Deploying image to Google Container Engine..."
-docker build -t "$imageName" .
-docker tag "$imageName" "$imageUrl"
-gcloud docker -- push gcr.io/${projectName}/openjdk-gke-integration
+echo "Deploying image to Google Container Registry..."
+gcloud docker -- build -t "$imageName" .
+gcloud docker -- tag "$imageName" "$imageUrl"
+gcloud docker -- push gcr.io/${projectName}/${imageName}
 
 echo "Creating or searching for a Kubernetes cluster..."
 TEST_CLUSTER_EXISTENCE=$(gcloud container clusters list | awk "/$clusterName/")

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -17,7 +17,15 @@
 # Setup environment for CI.
 set -e
 
-dir=`dirname $0`
+readonly dir=`dirname $0`
+
+GetStatusOfContainerBuild () {
+  if [ "$1" -eq 0  ]; then
+    echo "PASSED"
+  else
+    echo "FAILED"
+  fi
+}
 
 imageUnderTest=$1
 if [ -z "${imageUnderTest}" ]; then
@@ -26,5 +34,13 @@ if [ -z "${imageUnderTest}" ]; then
 fi
 
 ${dir}/ae_integration_test.sh ${imageUnderTest}
+AE_OUTPUT=$?
+AE_STATUS=$(GetStatusOfContainerBuild "$AE_OUTPUT")
+
 ${dir}/gke_integration_test.sh ${imageUnderTest}
+GKE_OUTPUT=$?
+GKE_STATUS=$(GetStatusOfContainerBuild "$GKE_OUTPUT")
+
+echo "App Engine integration tests: $AE_STATUS"
+echo "Container Engine integration tests: $GKE_STATUS"
 

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -19,14 +19,6 @@ set -e
 
 readonly dir=`dirname $0`
 
-GetStatusOfContainerBuild () {
-  if [ "$1" -eq 0  ]; then
-    echo "PASSED"
-  else
-    echo "FAILED"
-  fi
-}
-
 imageUnderTest=$1
 if [ -z "${imageUnderTest}" ]; then
   echo "Usage: ${0} <image_under_test>"
@@ -34,13 +26,5 @@ if [ -z "${imageUnderTest}" ]; then
 fi
 
 ${dir}/ae_integration_test.sh ${imageUnderTest}
-AE_OUTPUT=$?
-AE_STATUS=$(GetStatusOfContainerBuild "$AE_OUTPUT")
 
 ${dir}/gke_integration_test.sh ${imageUnderTest}
-GKE_OUTPUT=$?
-GKE_STATUS=$(GetStatusOfContainerBuild "$GKE_OUTPUT")
-
-echo "App Engine integration tests: $AE_STATUS"
-echo "Container Engine integration tests: $GKE_STATUS"
-

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # Setup environment for CI.
+# This script exits as soon as any of the commands in the integration scripts fail
+# (including remote failure from Google Cloud Container Builder)
 set -e
 
 readonly dir=`dirname $0`

--- a/test-application/pom.xml
+++ b/test-application/pom.xml
@@ -65,6 +65,10 @@
                   <directory>${basedir}/src/main/docker</directory>
                   <filtering>false</filtering>
                 </resource>
+                <resource>
+                  <directory>${basedir}/src/main/kubernetes</directory>
+                  <filtering>false</filtering>
+                </resource>
               </resources>
             </configuration>
           </execution>

--- a/test-application/src/main/kubernetes/openjdk-spring-boot.yaml.in
+++ b/test-application/src/main/kubernetes/openjdk-spring-boot.yaml.in
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openjdk-spring-boot
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: openjdk-spring-boot-app
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: openjdk-spring-boot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: openjdk-spring-boot
+      labels:
+        app: openjdk-spring-boot-app
+    spec:
+      containers:
+      - name: openjdk-spring-boot
+        image: ${TESTED_IMAGE}
+        resources:
+          requests:
+            cpu: 100m
+            memory: "512Mi"
+          limits:
+            cpu: 200m
+            memory: "1024Mi"
+        env:
+        - name: HEAP_SIZE_RATIO
+          value: "50"
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
Add a script to setup environment for integration test on GKE using [runtimes-common integration testing framework](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/integration_tests)

The script does the following steps: 
- Build a test application into a docker image
- Upload the image to Google Container Registry
- Create a Kubernetes cluster on GKE
- Deploy the application
- Run the integration test

It assumes that kubectl executable is available.

This PR fixes #96 