### PR TITLE
Set the default zone when installing gcloud for integration tests

### DIFF
--- a/scripts/gcloud-init.sh
+++ b/scripts/gcloud-init.sh
@@ -44,4 +44,5 @@ export PATH=$DIR/google-cloud-sdk/bin:$PATH
 
 gcloud auth activate-service-account --key-file=$KEYFILE
 gcloud config set project $GCP_PROJECT
+gcloud config set compute/zone us-east1-b
 gcloud components install beta kubectl -q


### PR DESCRIPTION
Tests fail unless this field is set.