### PR TITLE
Follow symlinks to find java

### DIFF
--- a/openjdk8/src/main/docker/docker-entrypoint.bash
+++ b/openjdk8/src/main/docker/docker-entrypoint.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # If the first argument is the full java command
-if [ "$(which java)" = "$1" ] ; then
-  #normalize it
+if [ "$(which java)" = "$1" -o "$(readlink -f $(which java))" = "$1" ] ; then
+  # normalize it
   shift
   set -- java "$@"
 # else if the first argument is not executable assume java


### PR DESCRIPTION
Adds a check that follows symlinks to try to identify if the entrypoint's first arg is a java command. 

The ultimate location of the java executable in this container is two symlinks away from the `java` command; this change allows the entrypoint to recognize invocations of ` /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java` as valid "java" commands.

```
root@fdc0657e8591:/# which java
/usr/bin/java
root@fdc0657e8591:/# ls -l /usr/bin/java
lrwxrwxrwx 1 root root 22 May 30 19:57 /usr/bin/java -> /etc/alternatives/java
root@fdc0657e8591:/# ls -l /etc/alternatives/java
lrwxrwxrwx 1 root root 46 May 30 19:57 /etc/alternatives/java -> /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
root@fdc0657e8591:/# ls -l /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-rwxr-xr-x 1 root root 6408 May  3 15:07 /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
``` 