### PR TITLE
Normalize 'java' commands so we can inject JAVA_OPTS

### DIFF
--- a/openjdk8/src/main/docker/docker-entrypoint.bash
+++ b/openjdk8/src/main/docker/docker-entrypoint.bash
@@ -33,5 +33,6 @@ if [ "$1" = "java" -a -n "$JAVA_OPTS" ]; then
 fi
 
 # exec the entry point arguments as a command
+echo "Start command: $@"
 exec "$@"
 

--- a/openjdk8/src/main/docker/docker-entrypoint.bash
+++ b/openjdk8/src/main/docker/docker-entrypoint.bash
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# If the first argument is the full java command
-if [ "$(which java)" = "$1" -o "$(readlink -f $(which java))" = "$1" ] ; then
-  # normalize it
+is_java_cmd() {
+  [ "$(which java)" = "$1" -o "$(readlink -f $(which java))" = "$1" ]
+}
+
+# Normalize invocations of "java" so that other scripts can more easily detect it
+if is_java_cmd "$1"; then
   shift
   set -- java "$@"
 # else if the first argument is not executable assume java
@@ -15,6 +18,12 @@ if [ -d "${SETUP_ENV:=/setup-env.d}" ]; then
   for SCRIPT in $( ls "${SETUP_ENV}/"[0-9]*.bash | sort ) ; do
     source ${SCRIPT}
   done
+fi
+
+# Normalize invocations of "java" again in case other scripts have modified it
+if is_java_cmd "$1"; then
+  shift
+  set -- java "$@"
 fi
 
 # Do we have JAVA_OPTS for a java command?


### PR DESCRIPTION
This PR normalizes java commands in the docker-entrypoint a second time, after all scripts in the setup-env.d directory have been run. This ensures that we are able to mix in JAVA_OPTS, even if other scripts modify the java command.

part of the fix to https://github.com/GoogleCloudPlatform/jetty-runtime/issues/182