### PR TITLE
Use maven cloud builder image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,8 +3,8 @@
 
 steps:
 # Build the maven project, omitting the docker build step
-- name: 'maven:3.3.9-jdk-8'
-  args: ['mvn', '-P-local-docker-build', '-Ddocker.tag.long=${_DOCKER_TAG}', 'clean', 'install']
+- name: 'gcr.io/cloud-builders/java/mvn:3.3.9-jdk-8'
+  args: ['-P-local-docker-build', '-Ddocker.tag.long=${_DOCKER_TAG}', 'clean', 'install']
   id: 'MAVEN'
 # Execute the docker build
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
We should use our own maven cloud builder image. This will make builds faster since official images are cached within Cloud Container Builder, and will not need to be fetched at build time.