### PR TITLE
small improvements for development guide

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,7 +5,7 @@ This document contains instructions on how to build and test this image.
 # Building the image
 
 ### Local build
-To build the image you need git, docker and maven installed:
+To build the image you need git, docker (your user needs to be part of the ``docker`` group to run docker without sudo) and maven installed:
 ```
 $ git clone https://github.com/GoogleCloudPlatform/openjdk-runtime.git
 $ cd openjdk-runtime

--- a/scripts/cloudbuild_local.sh
+++ b/scripts/cloudbuild_local.sh
@@ -16,5 +16,5 @@
 
 set -e
 
-cloudBuildScript="https://raw.githubusercontent.com/GoogleCloudPlatform/python-runtime/master/scripts/local_cloudbuild.py"
+cloudBuildScript="https://raw.githubusercontent.com/GoogleCloudPlatform/python-runtime/b9aaae5d441a8e63698d6a101191545183278362/scripts/local_cloudbuild.py"
 curl -s $cloudBuildScript | python3 - "$@" --output_script=`mktemp`


### PR DESCRIPTION
As I went through the build the first time (both cloud and local) I ran into two issues:
* my user did not have docker group setup - and that is assumed by the build script, so I mentioned that assumption explicitly in the guide 
* for the "local emulation" of the cloud build, a python script is pulled in from the python runtime - which is not an ideal solution necessarily - especially that the old version (the one I switched back to) worked, the new version doesn't, as it got modularized in [this commit ](https://github.com/GoogleCloudPlatform/python-runtime/commit/6f2275b44ff4a4b083f013f014fc37849952c79e) - I'll put in an issue to have a better fix than just depending on an older version