### PR TITLE
adding deployment token as a check before integration tests

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -23,12 +23,17 @@ readonly dir=`dirname $0`
 
 imageUnderTest=$1
 if [ -z "${imageUnderTest}" ]; then
-  echo "Usage: ${0} <image_under_test>"
+  echo "Usage: ${0} <image_under_test> [gae_deployment_version]"
   exit 1
 fi
 
+# for local tests it makes sense sometimes to pin the deployment to an
+# active version as that will speed up the deployment, for CI/CD this feature
+# is not recommended
+readonly gaeDeploymentVersion=$2
+
 ${dir}/local_integration_test.sh ${imageUnderTest}
 
-${dir}/ae_integration_test.sh ${imageUnderTest}
+${dir}/ae_integration_test.sh ${imageUnderTest} ${gaeDeploymentVersion}
 
 ${dir}/gke_integration_test.sh ${imageUnderTest}

--- a/scripts/local_integration_test.sh
+++ b/scripts/local_integration_test.sh
@@ -26,6 +26,7 @@ readonly deployDir="$testAppDir/target/deploy"
 APP_IMAGE='openjdk-local-integration'
 CONTAINER=${APP_IMAGE}-container
 OUTPUT_FILE=${CONTAINER}-output.txt
+DEPLOYMENT_TOKEN=$(uuidgen)
 
 readonly imageUnderTest=$1
 if [[ -z "$imageUnderTest" ]]; then
@@ -35,7 +36,7 @@ fi
 
 # build the test app
 pushd ${testAppDir}
-mvn clean install -DskipTests --batch-mode
+mvn clean package -Ddeployment.token="${DEPLOYMENT_TOKEN}" -DskipTests --batch-mode
 popd
 
 # build app container locally
@@ -45,9 +46,11 @@ envsubst < Dockerfile.in > Dockerfile
 echo "Building app container..."
 docker build -t $APP_IMAGE . || gcloud docker -- build -t $APP_IMAGE .
 
+docker rm -f $CONTAINER || echo "Integration-test-app container is not running, ready to start a new instance."
+
 # run app container locally to test shutdown logging
 echo "Starting app container..."
-docker run --rm --name $CONTAINER -e "SHUTDOWN_LOGGING_THREAD_DUMP=true" -e "SHUTDOWN_LOGGING_HEAP_INFO=true" $APP_IMAGE &> $OUTPUT_FILE &
+docker run --rm --name $CONTAINER -p 8080 -e "SHUTDOWN_LOGGING_THREAD_DUMP=true" -e "SHUTDOWN_LOGGING_HEAP_INFO=true" $APP_IMAGE &> $OUTPUT_FILE &
 
 function waitForOutput() {
   found_output='false'
@@ -65,6 +68,20 @@ function waitForOutput() {
 }
 
 waitForOutput 'Started Application'
+
+getPort() {
+   docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}}{{(index $conf 0).HostPort}}{{end}}' ${CONTAINER}
+}
+
+
+PORT=`getPort`
+
+echo port is $PORT
+
+until [[ $(curl --silent --fail "http://localhost:$PORT/deployment.token" | grep "$DEPLOYMENT_TOKEN") ]]; do
+  sleep 2
+done
+
 
 docker stop $CONTAINER
 

--- a/test-application/pom.xml
+++ b/test-application/pom.xml
@@ -24,6 +24,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <deployment.token>default_deployment_token</deployment.token>
   </properties>
 
   <dependencies>

--- a/test-application/src/main/java/com/google/cloud/runtimes/DeploymentTokenController.java
+++ b/test-application/src/main/java/com/google/cloud/runtimes/DeploymentTokenController.java
@@ -1,0 +1,21 @@
+package com.google.cloud.runtimes;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@RestController
+public class DeploymentTokenController {
+
+  @Value("${deployment.token}")
+  private String deploymentToken;
+
+  @RequestMapping(path = "/deployment.token", method = GET)
+  public String deploymentToken() {
+    return deploymentToken;
+  }
+
+
+}

--- a/test-application/src/main/resources/application.properties
+++ b/test-application/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 monitoring.write.retries=3
+deployment.token=@deployment.token@


### PR DESCRIPTION
Mitigates further race conditions that result in 502 on AppEngine and hung tests for GKE. 
