### PR TITLE
Unique GKE clusters for integration tests

### DIFF
--- a/scripts/gke_cluster_cleanup.yaml
+++ b/scripts/gke_cluster_cleanup.yaml
@@ -1,5 +1,5 @@
 # Cloud Builder pipeline for tearing down integration test resources
 steps:
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: ['--quiet', 'container', 'clusters', 'delete', '$_CLUSTER_NAME']
+    args: ['--quiet', 'container', 'clusters', 'delete', '$_CLUSTER_NAME', '--zone=$_ZONE']
 

--- a/scripts/gke_cluster_cleanup.yaml
+++ b/scripts/gke_cluster_cleanup.yaml
@@ -1,5 +1,5 @@
 # Cloud Builder pipeline for tearing down integration test resources
 steps:
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: ['--quiet', 'app', 'versions', 'delete', '$_VERSION']
+    args: ['--quiet', 'container', 'clusters', 'delete', '$_CLUSTER_NAME']
 

--- a/scripts/gke_integration_test.sh
+++ b/scripts/gke_integration_test.sh
@@ -43,12 +43,17 @@ readonly projectName=$(gcloud info \
                 | sed 's/\]//')
 readonly imageName="openjdk-gke-integration:$TAG"
 readonly imageUrl="gcr.io/$projectName/$imageName"
-readonly clusterName="openjdk-gke-integration"
 
 readonly imageUnderTest=$1
+clusterName=$2
 if [[ -z "$imageUnderTest" ]]; then
-  echo "Usage: ${0} <image_under_test>"
+  echo "Usage: ${0} <image_under_test> [gke_cluster_name]"
   exit 1
+fi
+
+if [[ -z "$clusterName" ]]; then
+ clusterName=$(uuidgen)
+ readonly tearDown="true"
 fi
 
 # build the test app
@@ -96,3 +101,13 @@ gcloud container builds submit \
   --config ${dir}/integration_test.yaml \
   --substitutions "_DEPLOYED_APP_URL=http://$DEPLOYED_APP_URL" \
   ${dir}
+
+# teardown any resources we created
+if [ "$tearDown" == "true" ]; then
+  # run a cleanup build once tests have finished executing
+  gcloud container builds submit \
+    --config $dir/gke_cluster_cleanup.yaml \
+    --substitutions "_CLUSTER_NAME=$clusterName" \
+    --async \
+    --no-source
+fi


### PR DESCRIPTION
Integration tests spin up and teardown unique GKE clusters for each test execution. This helps mitigate collisions when running tests concurrently. 

See also https://github.com/GoogleCloudPlatform/openjdk-runtime/pull/143 for similar work.