### PR TITLE
Fix random string generation

### DIFF
--- a/scripts/gke_integration_test.sh
+++ b/scripts/gke_integration_test.sh
@@ -53,7 +53,8 @@ if [[ -z "$imageUnderTest" ]]; then
 fi
 
 if [[ -z "$clusterName" ]]; then
- clusterName=$(uuidgen)
+ # generate random alpha string
+ clusterName=$(cat /dev/urandom | tr -dc 'a-z' | fold -w 20 | head -n 1)
  readonly tearDown="true"
 fi
 


### PR DESCRIPTION
`uuidgen` will not work as a means for generating valid GKE cluster names - they must start with a letter and be shorter than 40 chars. Instead, we should just use a string of 20 random lowercase letters. 