### PR TITLE
Fix war deployments for test app

### DIFF
--- a/java-runtimes-common/test-spring-application/README.md
+++ b/java-runtimes-common/test-spring-application/README.md
@@ -8,14 +8,26 @@ The test application is a simple [Spring Boot](https://projects.spring.io/spring
 which can be built in several different ways.
 
 ## Supported profiles
+### Runtime staging profiles
+**Java runtime profile (default)** - prepares files in the `target/deploy` directory for deployment to the default Java runtime on App Engine Flexible:
+```bash
+mvn install -Pruntime.java
+```
 **Custom runtime profile** - prepares files in the `target/deploy` directory for deployment to a custom runtime on App Engine Flexible:
   - When using this profile, the `app.deploy.image` property must be specified as well.
 ```bash
 mvn install -Pruntime.custom -Dapp.deploy.image=gcr.io/google-appengine/openjdk
 ```
-**Java runtime profile** - prepares files in the `target/deploy` directory for deployment to the default Java runtime on App Engine Flexible:
+
+### Deployment profiles
+**JAR deployment profile (default)** - packages the application as an executable JAR that embeds a web server.
 ```bash
-mvn install -Pruntime.java
+mvn install -Pdeploy.jar
+```
+
+**WAR deployment profile** - packages the application as a WAR file that can be deployed to a web server instance.
+```bash
+mvn install -Pdeploy.war
 ```
 
 ## Supported packaging types

--- a/java-runtimes-common/test-spring-application/README.md
+++ b/java-runtimes-common/test-spring-application/README.md
@@ -9,6 +9,8 @@ which can be built in several different ways.
 
 ## Supported profiles
 ### Runtime staging profiles
+Runtime staging profiles can be mixed & matched with deployment profiles.
+
 **Java runtime profile (default)** - prepares files in the `target/deploy` directory for deployment to the default Java runtime on App Engine Flexible:
 ```bash
 mvn install -Pruntime.java
@@ -20,20 +22,15 @@ mvn install -Pruntime.custom -Dapp.deploy.image=gcr.io/google-appengine/openjdk
 ```
 
 ### Deployment profiles
+Deployment profiles can be mixed & matched with runtime staging profiles.
+
 **JAR deployment profile (default)** - packages the application as an executable JAR that embeds a web server.
 ```bash
 mvn install -Pdeploy.jar
 ```
-
 **WAR deployment profile** - packages the application as a WAR file that can be deployed to a web server instance.
 ```bash
 mvn install -Pdeploy.war
 ```
-
-## Supported packaging types
-The test application can be packaged using variable packaging types. Select among them using the
-`packaging.type` maven property. These can be mixed with the various profiles above. Supported packaging types:
-- `mvn install -Dpackaging.type=jar`
-- `mvn install -Dpackaging.type=war`
 
 

--- a/java-runtimes-common/test-spring-application/pom.xml
+++ b/java-runtimes-common/test-spring-application/pom.xml
@@ -26,7 +26,6 @@
     <deployment.token>default_deployment_token</deployment.token>
     <packaging.type>jar</packaging.type>
     <app.deploy.runtime>java</app.deploy.runtime>
-    <app.deploy.image></app.deploy.image>
   </properties>
 
   <dependencies>

--- a/java-runtimes-common/test-spring-application/pom.xml
+++ b/java-runtimes-common/test-spring-application/pom.xml
@@ -24,6 +24,9 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <deployment.token>default_deployment_token</deployment.token>
+    <packaging.type>jar</packaging.type>
+    <app.deploy.runtime>java</app.deploy.runtime>
+    <app.deploy.image></app.deploy.image>
   </properties>
 
   <dependencies>
@@ -110,7 +113,6 @@
       </activation>
       <properties>
         <app.deploy.runtime>custom</app.deploy.runtime>
-        <app.deploy.image></app.deploy.image>
       </properties>
       <build>
         <plugins>

--- a/java-runtimes-common/test-spring-application/pom.xml
+++ b/java-runtimes-common/test-spring-application/pom.xml
@@ -24,7 +24,6 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <deployment.token>default_deployment_token</deployment.token>
-    <packaging.type>jar</packaging.type>
   </properties>
 
   <dependencies>
@@ -81,6 +80,15 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>deploy.jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <packaging.type>jar</packaging.type>
+      </properties>
+    </profile>
     <profile>
       <id>deploy.war</id>
       <properties>

--- a/java-runtimes-common/test-spring-application/pom.xml
+++ b/java-runtimes-common/test-spring-application/pom.xml
@@ -82,6 +82,19 @@
 
   <profiles>
     <profile>
+      <id>deploy.war</id>
+      <properties>
+        <packaging.type>war</packaging.type>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <!-- stage the application for deployment to a custom runtime -->
       <id>runtime.custom</id>
       <activation>

--- a/java-runtimes-common/test-spring-application/src/main/java/com/google/cloud/runtimes/Application.java
+++ b/java-runtimes-common/test-spring-application/src/main/java/com/google/cloud/runtimes/Application.java
@@ -2,10 +2,18 @@ package com.google.cloud.runtimes;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
 
 @SpringBootApplication
-public class Application {
+public class Application extends SpringBootServletInitializer {
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
+
+	@Override
+	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+		return application.sources(Application.class);
+	}
+
 }


### PR DESCRIPTION
Makes a few more final tweaks that are required in order to package the test app as a WAR file that works on jetty/tomcat webservers. Because some dependency management is required to produce a Spring Boot WAR file, the JAR/WAR switch was moved from a maven property to a maven profile.

See also https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-create-a-deployable-war-file

