### PR TITLE
Do not build the mvn-gcloud builder image during Cloud Build executions

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,14 +22,8 @@ steps:
   args: ['push', '${_STAGING_IMAGE}']
   id: 'PUSH_STAGING_IMG'
 
-# Build a 'builder' image for running integration tests
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=mvn-gcloud', 'java-runtimes-common/mvn-gcloud-image']
-  waitFor: ['-']
-  id: 'BUILD_MVN_GCLOUD'
-
 # Execute integration tests
-- name: 'mvn-gcloud'
+- name: 'gcr.io/java-runtime-test/mvn-gcloud-builder'
   entrypoint: 'scripts/integration_test.sh'
   args: ['${_STAGING_IMAGE}']
   id: 'INTEGRATION_TEST'


### PR DESCRIPTION
I set up a build trigger that will rebuild and push the `gcr.io/java-runtime-test/mvn-gcloud-builder` image on every push to master. Now, we don't need to rebuild this image during Cloud Build executions.

fixes #155

