### PR TITLE
Use preferred cloud-builders image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 
 steps:
 # Build the openjdk image
-- name: 'gcr.io/cloud-builders/java/mvn:3.3.9-jdk-8'
+- name: 'gcr.io/cloud-builders/mvn:3.3.9-jdk-8'
   args:
   - 'clean'
   - 'install'

--- a/java-runtimes-common/mvn-gcloud-image/Dockerfile
+++ b/java-runtimes-common/mvn-gcloud-image/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for building a test container that includes java, maven, and the Google Cloud SDK.
 # This is intended to be used as part of a Google Cloud Container Builder build.
 
-FROM gcr.io/cloud-builders/java/mvn:3.3.9-jdk-8
+FROM gcr.io/cloud-builders/mvn:3.3.9-jdk-8
 
 ARG CLOUD_SDK_VERSION=172.0.0
 


### PR DESCRIPTION
We recently moved the mvn builder up to the top-level.