### PR TITLE
Replace "Container Engine" by "Kubernetes Engine".

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -48,7 +48,7 @@ Before running, make sure you have done all of the following:
 
 # Running Tests
 Integration tests can be run via [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/overview).
-These tests deploy a sample test application to App Engine and to Google Container Engine using the provided runtime image, and
+These tests deploy a sample test application to App Engine and to Google Kubernetes Engine using the provided runtime image, and
 exercise various integrations with other GCP services. Note that the image under test must be pushed 
 to a gcr.io repository before the integration tests can run.
 
@@ -57,7 +57,7 @@ $ RUNTIME_IMAGE=gcr.io/my-project-id/openjdk:my-tag
 $ gcloud docker -- push $RUNTIME_IMAGE
 ```
 
-**Run ALL integration tests (Local Docker, App Engine, Google Container Engine):**
+**Run ALL integration tests (Local Docker, App Engine, Google Kubernetes Engine):**
 ```bash
 $ ./scripts/integration_test.sh $RUNTIME_IMAGE
 ```
@@ -78,7 +78,7 @@ $ ./scripts/local_shutdown_test.sh $RUNTIME_IMAGE
 $ ./scripts/ae_integration_test.sh $RUNTIME_IMAGE
 ```
 
-**Run ONLY Container Engine (GKE) integration tests:**
+**Run ONLY Kubernetes Engine (GKE) integration tests:**
 ```bash
 $ ./scripts/gke_integration_test.sh $RUNTIME_IMAGE
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Google Cloud Platform OpenJDK Docker Image
 
-This repository contains the source for the Google-maintained OpenJDK [docker](https://docker.com) image. This image can be used as the base image for running Java applications on [Google App Engine Flexible Environment](https://cloud.google.com/appengine/docs/flexible/java/) and [Google Container Engine](https://cloud.google.com/container-engine).
+This repository contains the source for the Google-maintained OpenJDK [docker](https://docker.com) image. This image can be used as the base image for running Java applications on [Google App Engine Flexible Environment](https://cloud.google.com/appengine/docs/flexible/java/) and [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine).
 
 ## Repository/Tag Details
 Supported images/tags include:
@@ -43,7 +43,7 @@ Once you have this configuration, you can use the Google Cloud SDK to deploy thi
 gcloud app deploy app.yaml
 ```
 
-## Container Engine & other Docker hosts
+## Kubernetes Engine & other Docker hosts
 For other Docker hosts, you'll need to create a Dockerfile based on this image that copies your application code and installs dependencies. For example:
 
 ```dockerfile

--- a/scripts/gke_integration_test.sh
+++ b/scripts/gke_integration_test.sh
@@ -63,7 +63,7 @@ pushd ${testAppDir}
 mvn clean install -Pruntime.custom -Dapp.deploy.image=$imageUnderTest -Ddeployment.token="${DEPLOYMENT_TOKEN}" -DskipTests --batch-mode
 popd
 
-# deploy to Google Container Engine
+# deploy to Google Kubernetes Engine
 pushd ${deployDir}
 export TESTED_IMAGE=${imageUrl}
 envsubst < "openjdk-spring-boot.yaml.in" > "openjdk-spring-boot.yaml"
@@ -79,7 +79,7 @@ if [ -z "$TEST_CLUSTER_EXISTENCE" ]; then
   gcloud container clusters create "$clusterName" --num-nodes=1 --disk-size=10 --zone="$defaultZone"
 fi
 
-echo "Deploying application to Google Container Engine..."
+echo "Deploying application to Google Kubernetes Engine..."
 gcloud container clusters get-credentials ${clusterName} --zone="$defaultZone"
 kubectl apply -f "openjdk-spring-boot.yaml"
 popd


### PR DESCRIPTION
Also rename a link to https://cloud.google.com/container-engine/.