### PR TITLE
Added MAX_HEAP_SIZE_MB to avoid a calculated size being too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If the default command (java) is used, then the entry point sources the [setup-e
 |`GAE_MEMORY_MB`                     | Available memory    | size     | Set by GAE or `/proc/meminfo`-400M          |
 |`HEAP_SIZE_RATIO`                   | Memory for the heap | percent  | 80                                          |
 |`HEAP_SIZE_MB`                      | Available heap      | size     | `${HEAP_SIZE_RATIO}`% of `${GAE_MEMORY_MB}` |
+|`MAX_HEAP_SIZE_MB`                  | Max calculated heap | size     | 20 * 1024                                   |
 |`JAVA_HEAP_OPTS`                    | JVM heap args       | JVM args | `-Xms${HEAP_SIZE_MB}M -Xmx${HEAP_SIZE_MB}M` |
 |`JAVA_GC_OPTS`                      | JVM GC args         | JVM args | `-XX:+UseG1GC` plus configuration           |
 |`JAVA_USER_OPTS`                    | JVM other args      | JVM args |                                             |

--- a/openjdk-common/src/main/docker/setup-env.d/30-java-env.bash
+++ b/openjdk-common/src/main/docker/setup-env.d/30-java-env.bash
@@ -32,7 +32,13 @@ GetAvailableMemory () {
 export JAVA_TMP_OPTS=${JAVA_TMP_OPTS:-$( if [[ -z ${TMPDIR} ]]; then echo ""; else echo "-Djava.io.tmpdir=$TMPDIR"; fi)}
 export GAE_MEMORY_MB=${GAE_MEMORY_MB:-$(GetAvailableMemory)}
 export HEAP_SIZE_RATIO=${HEAP_SIZE_RATIO:-"80"}
-export HEAP_SIZE_MB=${HEAP_SIZE_MB:-$(expr ${GAE_MEMORY_MB} \* ${HEAP_SIZE_RATIO} / 100)}
+if [ -z $HEAP_SIZE_MB ]; then
+  HEAP_SIZE_MB=$(expr ${GAE_MEMORY_MB} \* ${HEAP_SIZE_RATIO} / 100)
+  MAX_HEAP_SIZE_MB=${MAX_HEAP_SIZE_MB:-$(expr 20 \* 1024)}
+  if [ $HEAP_SIZE_MB -gt $MAX_HEAP_SIZE_MB ]; then
+    export HEAP_SIZE_MB=$MAX_HEAP_SIZE_MB
+  fi
+fi
 export JAVA_HEAP_OPTS=${JAVA_HEAP_OPTS:-"-Xms${HEAP_SIZE_MB}M -Xmx${HEAP_SIZE_MB}M"}
 export JAVA_GC_OPTS=${JAVA_GC_OPTS:-"-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+PrintCommandLineFlags"}
 export JAVA_OPTS=${JAVA_OPTS:--showversion ${JAVA_TMP_OPTS} ${DBG_AGENT} ${PROFILER_AGENT} ${JAVA_HEAP_OPTS} ${JAVA_GC_OPTS} ${JAVA_USER_OPTS}}


### PR DESCRIPTION
When deployed on systems with large available memory, the automatic calculated heap size may be too large for the JVM.
This PR applies a limit to the calculated heap size.
